### PR TITLE
Add installation instructions for java sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ reduce verbosity.
 ## Installation
 `npm install webdriver-sync`
 
+This package requires java and the java opensdk.
+* Linux: 
+   * RHEL # `yum install -y java-devel`
+   * Debian/Ubuntu # `apt-get install java-sdk`
+
+
 `webdriver-sync` will download needed binaries for you which makes your life
 easier.  `webdriver-sync` will download these binaries to `$HOME/.webdriver-sync`.
 The following list has ways of overriding this process:


### PR DESCRIPTION
I spent some time figuring out that it was the java sdk that was missing and that it was throwing errors because it couldn't find JAVA_HOME. I thought this would clarify it for other users
