### PR TITLE
Allow FirefoxProfile as argument to FirefoxDriver constructor

### DIFF
--- a/src/classes/FirefoxDriver.js
+++ b/src/classes/FirefoxDriver.js
@@ -29,8 +29,7 @@ function FirefoxDriver(
   if (!len) {
     instance = new Class();
   } else if (len === 1 || len === 2) {
-    assert(first)
-      .(isInstanceof(Capabilities) || isInstanceof(FirefoxProfile))
+    assert(first.isInstanceof(Capabilities) || first.isInstanceof(FirefoxProfile))
       .throws(
         "The first argument wasn't an instanceof either Capabilities or FirefoxProfile."
         );


### PR DESCRIPTION
I've made a very basic change to fix issue #50 but it needs a test - probably a new one for FirefoxDriver?
