### PR TITLE
READY: Allow web elements to be passed to clickable

### DIFF
--- a/src/classes/ExpectedConditions.js
+++ b/src/classes/ExpectedConditions.js
@@ -24,9 +24,9 @@ ExpectedConditions.elementSelectionStateToBe = function(arg, isSelected) {
     );
 };
 
-ExpectedConditions.elementToBeClickable = function(by) {
-  assertBy(by, 'first');
-  return new ExpectedCondition(Class.elementToBeClickableSync(by._instance));
+ExpectedConditions.elementToBeClickable = function(arg) {
+  assertByOrWebElement(arg, 'first');
+  return new ExpectedCondition(Class.elementToBeClickableSync(arg._instance));
 };
 
 ExpectedConditions.elementToBeSelected = function(arg) {
@@ -83,17 +83,17 @@ ExpectedConditions.stalenessOf = function(webElement) {
   return new ExpectedCondition(Class.stalenessOfSync(webElement._instance));
 };
 
-ExpectedConditions.textToBePresentInElement = function(by, text) {
-  assertBy(by, 'first');
+ExpectedConditions.textToBePresentInElement = function(arg, text) {
+  assertByOrWebElement(arg, 'first');
   return new ExpectedCondition(
-    Class.textToBePresentInElementSync(by._instance, text)
+    Class.textToBePresentInElementSync(arg._instance, text)
     );
 };
 
-ExpectedConditions.textToBePresentInElementValue = function(by, text) {
-  assertBy(by, 'first');
+ExpectedConditions.textToBePresentInElementValue = function(arg, text) {
+  assertByOrWebElement(arg, 'first');
   return new ExpectedCondition(Class.textToBePresentInElementValueSync(
-    by._instance,
+    arg._instance,
     text
     ));
 };

--- a/test/classes/ExpectedConditions.js
+++ b/test/classes/ExpectedConditions.js
@@ -23,6 +23,7 @@ describe('ExpectedConditions', function() {
     validate(ExpectedConditions.elementSelectionStateToBe(by, false));
     validate(ExpectedConditions.elementSelectionStateToBe(element, false));
     validate(ExpectedConditions.elementToBeClickable(by));
+    validate(ExpectedConditions.elementToBeClickable(element));
     validate(ExpectedConditions.elementToBeSelected(by));
     validate(ExpectedConditions.elementToBeSelected(element));
     validate(ExpectedConditions.frameToBeAvailableAndSwitchToIt('asdf'));
@@ -34,7 +35,9 @@ describe('ExpectedConditions', function() {
     validate(ExpectedConditions.refreshed(ExpectedConditions.alertIsPresent()));
     validate(ExpectedConditions.stalenessOf(element));
     validate(ExpectedConditions.textToBePresentInElement(by, 'ads'));
+    validate(ExpectedConditions.textToBePresentInElement(element, 'ads'));
     validate(ExpectedConditions.textToBePresentInElementValue(by, 'adsf'));
+    validate(ExpectedConditions.textToBePresentInElementValue(element, 'adsf'));
     validate(ExpectedConditions.titleContains('asdf'));
     validate(ExpectedConditions.titleIs('sdf'));
     validate(ExpectedConditions.visibilityOf(element));


### PR DESCRIPTION
According to [the ExpectedCondition docs](http://selenium.googlecode.com/git/docs/api/java/org/openqa/selenium/support/ui/ExpectedConditions.html), elementToBeClickable can take a By or a WebElement. In most cases, I've already got a web element and want to check it's state, so it would be nice to just pass the element.
