### PR TITLE
Implement `wait` helper method

### DIFF
--- a/src/webdriver-sync.js
+++ b/src/webdriver-sync.js
@@ -4,6 +4,9 @@ var java = require('java');
 var imports = require('./imports');
 var Long = imports.Long;
 
+var WAIT_DEFAULT_TIMEOUT = 1000;
+var WAIT_DEFAULT_PERIOD = 100;
+
 if(!process.env.WEBDRIVER_SYNC_ENABLE_SELENIUM_STDOUT){
   imports.helpers.ConsoleControl.stopOutSync();
 }
@@ -169,5 +172,42 @@ module.exports = {
       'sleep',
       new Long(amount)
       );
+  },
+  /**
+   * Utility method for blocking execution until some condition has been
+   * satisfied.
+   *
+   * @param {function} conditionFn Function that determines whether the `wait`
+   *                               has completed
+   * @param {object} [options]
+   * @param {number} [options.timeout] Time in milliseconds to wait before
+   *                                   considering the operation failed and
+   *                                   throwing an error
+   * @param {number} [options.period] Time in milliseconds to wait between
+   *                                  invocations of the `conditionFn`
+   */
+  wait: function(conditionFn, options) {
+    var waitStart = Date.now();
+
+    if (!options) {
+      options = {};
+    }
+    if (!('timeout' in options)) {
+      options.timeout = WAIT_DEFAULT_TIMEOUT;
+    }
+
+    if (!('period' in options)) {
+      options.period = WAIT_DEFAULT_PERIOD;
+    }
+
+    while (Date.now() - waitStart < options.timeout) {
+      if (conditionFn()) {
+        return;
+      }
+
+      module.exports.sleep(options.period);
+    }
+
+    throw new Error('`wd.wait` operation timed out');
   }
 };

--- a/test/webdriver-sync.js
+++ b/test/webdriver-sync.js
@@ -104,4 +104,50 @@ describe('webdriver-sync', function(){
       assert(end-start >= secondsToWait, 'sleep didn\'t work.');
     });
   });
+
+  describe('wait', function() {
+    var start;
+
+    beforeEach(function() {
+      start = Date.now();
+    });
+
+    it('should halt execution until the condition is satisfied', function() {
+      var count = 0;
+      wd.wait(function() {
+        return ++count === 2;
+      });
+
+      assert.equal(count, 2);
+    });
+
+    it('should throw an error after the provided timeout', function() {
+      var error;
+
+      try {
+        wd.wait(function() {
+          return false;
+        }, { timeout: 1000 });
+      } catch(err) {
+        error = err;
+      }
+
+      assert.ok(error);
+      assert(Date.now() - start >= 300);
+    });
+
+    it('should honor the specified polling period', function() {
+      var callTimes = [];
+      var perceivedPeriod;
+
+      wd.wait(function() {
+        callTimes.push(Date.now());
+        return callTimes.length === 2;
+      }, { timeout: 1000, period: 120 });
+
+      perceivedPeriod = callTimes[1] - callTimes[0];
+      assert(perceivedPeriod >= 120);
+      assert(perceivedPeriod < 200);
+    });
+  });
 });


### PR DESCRIPTION
@jsdevel I've modified the API a bit from what we drafted in gh-76; I think that requiring options be specified via named attributes of an `options` object makes the resulting code more readable (and also avoids problems like the "boolean trap", where users are forced to remember arbitrary argument ordering details).

> Allow users to specify an arbitrary JavaScript function as a waiting
> condition. This function will be called at an (overridable) interval
> until it returns a truthy value. If the function does not return a
> truthy value within an (overridable) timeout, throw an error.
