### PR TITLE
Bump selenium-binaries version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "async": "~0.2.9",
     "java": "0.6.1",
-    "selenium-binaries": "0.4.x"
+    "selenium-binaries": "0.10.x"
   },
   "devDependencies": {
     "jshint": "2.3.0",


### PR DESCRIPTION
Webdriver-sync no longer seems to work with latest chrome. Bumping the
selenium-binaries version seems to fix this.